### PR TITLE
Update README with correct stop command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You should now have an environment with the following:
 If you need to turn off LocalTerra:
 
 ```sh
-$ docker-compose down
+$ docker-compose stop
 ```
 
 To reset the world state, issue the following:


### PR DESCRIPTION
`docker-compose down` is equivalent to `docker-compose stop` and `docker-compose rm`. The `README` makes it sound like the given command will just _stop_ LocalTerra, but not reset the world state.