### PR TITLE
fix(genesis) update max_body_bytes to 4194304 from 1000000

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -136,7 +136,7 @@ max_subscriptions_per_client = 5
 timeout_broadcast_tx_commit = "10s"
 
 # Maximum size of request body, in bytes
-max_body_bytes = 1000000
+max_body_bytes = 4194304
 
 # Maximum size of request header, in bytes
 max_header_bytes = 1048576


### PR DESCRIPTION
### Overview

Increase default `max_body_bytes` to run Mirror integration tests on LocalTerra.