### PR TITLE
remove redundant parameters from genesis config

### DIFF
--- a/config/genesis.json
+++ b/config/genesis.json
@@ -706,13 +706,7 @@
       "params": {
         "max_contract_size": "512000",
         "max_contract_gas": "100000000",
-        "max_contract_msg_size": "1024",
-        "max_contract_data_size": "256",
-        "event_params": {
-          "max_attribute_num": "16",
-          "max_attribute_key_length": "64",
-          "max_attribute_value_length": "256"
-        }
+        "max_contract_msg_size": "1024"
       },
       "last_code_id": "0",
       "last_instance_id": "0",


### PR DESCRIPTION
Node is now starting and working. 
Collector still fails:
```
~ -> docker logs 0ea07e9d346a

> fcd@1.0.0-alpha.7 apidoc /app
> ts-node -T --files -r tsconfig-paths/register src/scripts/generateApidoc.ts

/app/apidoc-template/index.html
/app/static/index.html

> fcd@1.0.0-alpha.7 mergeswagger /app
> ts-node -T --files -r tsconfig-paths/register src/scripts/mergeSwaggerFile.ts "-o" "swagger.json"

Combined file saved in /app/static/swagger.json

> fcd@1.0.0-alpha.7 collector /app
> better-npm-run collector-prod

running better-npm-run in /app
Executing script: collector-prod

to be executed: node --stack_size=4096 --max-old-space-size=4096 -r ts-node/register/transpile-only -r tsconfig-paths/register src/collector/collector.ts
```