### PR TITLE
Change tax to zero rate and amount.

### DIFF
--- a/config/genesis.json
+++ b/config/genesis.json
@@ -667,13 +667,13 @@
     "treasury": {
       "params": {
         "tax_policy": {
-          "rate_min": "0.000500000000000000",
-          "rate_max": "0.010000000000000000",
+          "rate_min": "0.000000000000000000",
+          "rate_max": "0.000000000000000000",
           "cap": {
             "denom": "usdr",
-            "amount": "1000000"
+            "amount": "0"
           },
-          "change_rate_max": "0.000250000000000000"
+          "change_rate_max": "0.000000000000000000"
         },
         "reward_policy": {
           "rate_min": "0.000000000000000000",

--- a/config/genesis.json
+++ b/config/genesis.json
@@ -690,7 +690,7 @@
         "window_long": "52",
         "window_probation": "12"
       },
-      "tax_rate": "0.001000000000000000",
+      "tax_rate": "0.000000000000000000",
       "reward_weight": "0.050000000000000000",
       "tax_caps": [],
       "tax_proceeds": [],


### PR DESCRIPTION
As tax parameter was changed to zero on mainnet and testnet, LocalTerra also need to remove tax for interact other products like Terra station.