### PR TITLE
Added latest minimum RAM recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ LocalTerra has the following advantages over a public testnet:
 - [Docker](https://www.docker.com/)
 - [`docker-compose`](https://github.com/docker/compose)
 - Supported known architecture: x86_64
+- 16+ GB of RAM is recommended (for 8+ GB, [Bombay testnet](https://docs.terra.money/docs/develop/dapp/quick-start/using-terrain-testnet.html) is recommended)
 
 ## Install LocalTerra
 


### PR DESCRIPTION
Wasted some time installing LocalTerra per the Terra Academy course and this README, neither of which cautioned that LocalTerra may not work properly with less than 16 GB of RAM as recently noted here: https://docs.terra.money/docs/develop/dapp/quick-start/initial-setup.html