### PR TITLE
update pseudo-feeder to use timeout_commit in config.toml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,12 @@ services:
       - "9091:9091"
     command: terrad start
   oracle:
-    image: terramoney/pseudo-feeder:0.5.5
+    image: terramoney/pseudo-feeder:0.5.6
     pull_policy: always
     depends_on:
       - terrad
+    volumes:
+      - ./config/config.toml:/app/config.toml
     networks:
       - terra
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   terrad:
-    image: terramoney/localterra-core:0.5.14
+    image: terramoney/localterra-core:0.5.17
     pull_policy: always
     volumes:
       - ./config:/root/.terra/config
@@ -42,7 +42,7 @@ services:
   #   ports:
   #     - "6379:6379"
   fcd-collector:
-    image: terramoney/fcd:1.0.11
+    image: terramoney/fcd:1.0.14
     depends_on:
       - terrad
       - postgres
@@ -54,7 +54,7 @@ services:
     command: collector
     restart: unless-stopped
   fcd-api:
-    image: terramoney/fcd:1.0.11
+    image: terramoney/fcd:1.0.14
     depends_on:
       - terrad
       - postgres

--- a/pseudo-feeder/index.ts
+++ b/pseudo-feeder/index.ts
@@ -7,7 +7,7 @@ import {
 } from "@terra-money/terra.js";
 import { parse } from "toml";
 import * as fs from "fs";
-import { toMs } from 'ms-typescript'
+import * as ms from "ms"
 
 const {
   MAINNET_LCD_URL = "https://lcd.terra.dev",
@@ -27,8 +27,7 @@ const timeout_prevote_delta = toMs(config.consensus.timeout_prevote_delta); // 5
 const timeout_prevcommit = toMs(config.consensus.timeout_precommit); // 1s by default
 const timeout_precommit_delta = toMs(config.consensus.timeout_precommit_delta); // 500ms by default
 */
-const timeout_commit = toMs(config.consensus.timeout_commit); // 5s by default
-
+const timeoutCommit = ms(config.consensus.timeout_commit); // 5s by default
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -67,7 +66,7 @@ async function waitForFirstBlock(client: LCDClient) {
   console.info("waiting for first block");
 
   while (!shouldTerminate) {
-    await delay(timeout_commit);
+    await delay(timeoutCommit);
     shouldTerminate = await client.tendermint
       .blockInfo()
       .then(async (blockInfo) => {
@@ -80,7 +79,7 @@ async function waitForFirstBlock(client: LCDClient) {
       })
       .catch(async (err) => {
         console.error(err);
-        await delay(timeout_commit);
+        await delay(timeoutCommit);
         return false;
       });
 
@@ -138,7 +137,7 @@ async function loop() {
       (lastSuccessVotePeriod && (lastSuccessVotePeriod === currentVotePeriod)) ||
       (indexInVotePeriod >= oracleVotePeriod - 1)
     ) {
-      await delay(timeout_commit);
+      await delay(timeoutCommit);
       continue;
     }
 
@@ -168,9 +167,9 @@ async function loop() {
     }
     catch (err) {
       console.log(err.message);
-      delay(timeout_commit);
+      delay(timeoutCommit);
     };
-    await delay(timeout_commit * (oracleVotePeriod - 1));   // (period-1) because of broadcast
+    await delay(timeoutCommit * (oracleVotePeriod - 1));   // (period-1) because of broadcast
   }
 }
 
@@ -179,6 +178,6 @@ async function loop() {
 
   while (true) {
     await loop().catch(console.error);
-    await delay(timeout_commit * 5);
+    await delay(timeoutCommit * 5);
   }
 })();

--- a/pseudo-feeder/index.ts
+++ b/pseudo-feeder/index.ts
@@ -4,8 +4,10 @@ import {
   LCDClient,
   MnemonicKey,
   MsgAggregateExchangeRateVote,
-  Fee
 } from "@terra-money/terra.js";
+import { parse } from "toml";
+import * as fs from "fs";
+import { toMs } from 'ms-typescript'
 
 const {
   MAINNET_LCD_URL = "https://lcd.terra.dev",
@@ -14,6 +16,19 @@ const {
   TESTNET_CHAIN_ID = "localterra",
   MNEMONIC = "satisfy adjust timber high purchase tuition stool faith fine install that you unaware feed domain license impose boss human eager hat rent enjoy dawn",
 } = process.env;
+
+const config = parse(fs.readFileSync("./config.toml").toString());
+
+/* unused
+const timeout_propose = toMs(config.consensus.timeout_propose); // 3s by default
+const timeout_propose_delta = toMs(config.consensus.timeout_propose_delta);  // 500ms by default
+const timeout_prevote = toMs(config.consensus.timeout_prevote); // 1s by default
+const timeout_prevote_delta = toMs(config.consensus.timeout_prevote_delta); // 500ms by default
+const timeout_prevcommit = toMs(config.consensus.timeout_precommit); // 1s by default
+const timeout_precommit_delta = toMs(config.consensus.timeout_precommit_delta); // 500ms by default
+*/
+const timeout_commit = toMs(config.consensus.timeout_commit); // 5s by default
+
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -52,10 +67,10 @@ async function waitForFirstBlock(client: LCDClient) {
   console.info("waiting for first block");
 
   while (!shouldTerminate) {
+    await delay(timeout_commit);
     shouldTerminate = await client.tendermint
       .blockInfo()
       .then(async (blockInfo) => {
-        await delay(5000);
 
         if (blockInfo?.block) {
           return +blockInfo.block?.header.height > 0;
@@ -65,7 +80,7 @@ async function waitForFirstBlock(client: LCDClient) {
       })
       .catch(async (err) => {
         console.error(err);
-        await delay(1000);
+        await delay(timeout_commit);
         return false;
       });
 
@@ -97,23 +112,33 @@ async function loop() {
   let lastSuccessVotePeriod: number;
   let lastSuccessVoteMsg: MsgAggregateExchangeRateVote;
 
+  // to get initial rates and params
+  let [rates, oracleParams] = await Promise.all([
+    mainnetClient.oracle.exchangeRates(),
+    testnetClient.oracle.parameters(),
+  ]);
+
+  setInterval(async () => {
+    try {
+      [rates, oracleParams] = await Promise.all([
+        mainnetClient.oracle.exchangeRates(),
+        testnetClient.oracle.parameters(),
+      ]);
+    } catch (e) { }
+  }, 10000);  // 5s -> 10s: to avoid rate limit
+
   while (true) {
-    const [rates, oracleParams, latestBlock] = await Promise.all([
-      mainnetClient.oracle.exchangeRates(),
-      testnetClient.oracle.parameters(),
-      testnetClient.tendermint.blockInfo(),
-    ])
+    const latestBlock = await testnetClient.tendermint.blockInfo();
 
     const oracleVotePeriod = oracleParams.vote_period;
     const currentBlockHeight = parseInt(latestBlock.block.header.height, 10);
     const currentVotePeriod = Math.floor(currentBlockHeight / oracleVotePeriod);
     const indexInVotePeriod = currentBlockHeight % oracleVotePeriod;
-
     if (
-      (lastSuccessVotePeriod && lastSuccessVotePeriod === currentVotePeriod) ||
-      indexInVotePeriod >= oracleVotePeriod - 1
+      (lastSuccessVotePeriod && (lastSuccessVotePeriod === currentVotePeriod)) ||
+      (indexInVotePeriod >= oracleVotePeriod - 1)
     ) {
-      await delay(1000);
+      await delay(timeout_commit);
       continue;
     }
 
@@ -134,22 +159,18 @@ async function loop() {
     );
 
     const msgs = [lastSuccessVoteMsg, voteMsg.getPrevote()].filter(Boolean);
-    const tx = await wallet.createAndSignTx({ msgs, fee: new Fee(200000, '30000uusd') });
-
-    await testnetClient.tx
-      .broadcast(tx)
-      .then((result) => {
-        console.log(
-          `vote_period: ${currentVotePeriod}, txhash: ${result.txhash}`
-        );
-        lastSuccessVotePeriod = currentVotePeriod;
-        lastSuccessVoteMsg = voteMsg;
-      })
-      .catch((err) => {
-        console.error(err.message);
-      });
-
-    await delay(5000);
+    try {
+      const tx = await wallet.createAndSignTx({ msgs });
+      const result = await testnetClient.tx.broadcast(tx);
+      console.log(`vote_period: ${currentVotePeriod}, txhash: ${result.txhash}`);
+      lastSuccessVotePeriod = currentVotePeriod;
+      lastSuccessVoteMsg = voteMsg;
+    }
+    catch (err) {
+      console.log(err.message);
+      delay(timeout_commit);
+    };
+    await delay(timeout_commit * (oracleVotePeriod - 1));   // (period-1) because of broadcast
   }
 }
 
@@ -158,6 +179,6 @@ async function loop() {
 
   while (true) {
     await loop().catch(console.error);
-    await delay(5000);
+    await delay(timeout_commit * 5);
   }
 })();

--- a/pseudo-feeder/package-lock.json
+++ b/pseudo-feeder/package-lock.json
@@ -12,11 +12,11 @@
         "@terra-money/terra.js": "^3.0.8",
         "@types/node": "^17.0.8",
         "bluebird": "^3.7.2",
-        "ms-typescript": "^2.0.0",
+        "ms": "^2.1.3",
         "node-fetch": "^3.1.1",
+        "toml": "^3.0.0",
         "ts-node": "^10.7.0",
-        "typescript": "^4.1.3",
-        "typescript-plugin-toml": "^0.2.0"
+        "typescript": "^4.1.3"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {
@@ -564,10 +564,10 @@
         "node": "*"
       }
     },
-    "node_modules/ms-typescript": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms-typescript/-/ms-typescript-2.0.0.tgz",
-      "integrity": "sha512-47wAq6QgJZeFYqQ9k5PbBoyGhZsxOzwmTee2fna5+7coYuidaUFdACrKDbtOuLChFQOsSTS5dEyuplC52E5S8g=="
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nan": {
       "version": "2.15.0",
@@ -848,14 +848,6 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "node_modules/typescript-plugin-toml": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/typescript-plugin-toml/-/typescript-plugin-toml-0.2.0.tgz",
-      "integrity": "sha512-K8P1NI8A/SAVqapEnujbhXF0hjf6Qu/SoWsIFaTLszpbaOhnr9r7jddg41T6gj9w02u+3OW4NkWAI6veRMpp3Q==",
-      "dependencies": {
-        "toml": "^3.0.0"
       }
     },
     "node_modules/utf-8-validate": {
@@ -1404,10 +1396,10 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "ms-typescript": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms-typescript/-/ms-typescript-2.0.0.tgz",
-      "integrity": "sha512-47wAq6QgJZeFYqQ9k5PbBoyGhZsxOzwmTee2fna5+7coYuidaUFdACrKDbtOuLChFQOsSTS5dEyuplC52E5S8g=="
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "nan": {
       "version": "2.15.0",
@@ -1600,14 +1592,6 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
       "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg=="
-    },
-    "typescript-plugin-toml": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/typescript-plugin-toml/-/typescript-plugin-toml-0.2.0.tgz",
-      "integrity": "sha512-K8P1NI8A/SAVqapEnujbhXF0hjf6Qu/SoWsIFaTLszpbaOhnr9r7jddg41T6gj9w02u+3OW4NkWAI6veRMpp3Q==",
-      "requires": {
-        "toml": "^3.0.0"
-      }
     },
     "utf-8-validate": {
       "version": "5.0.8",

--- a/pseudo-feeder/package-lock.json
+++ b/pseudo-feeder/package-lock.json
@@ -9,12 +9,14 @@
       "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
-        "@terra-money/terra.js": "^3.0.3",
+        "@terra-money/terra.js": "^3.0.8",
         "@types/node": "^17.0.8",
         "bluebird": "^3.7.2",
+        "ms-typescript": "^2.0.0",
         "node-fetch": "^3.1.1",
-        "ts-node": "^10.0.0",
-        "typescript": "^4.1.3"
+        "ts-node": "^10.7.0",
+        "typescript": "^4.1.3",
+        "typescript-plugin-toml": "^0.2.0"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {
@@ -91,9 +93,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@terra-money/terra.js": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@terra-money/terra.js/-/terra.js-3.0.4.tgz",
-      "integrity": "sha512-PEYaPs0p521njZyD6a7aH6KrXRKdj4+j7kboM4qGc8FS/lKPFQUgacsVSlbAK0sYX/tOhINvN7eudwRBwuJVhw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@terra-money/terra.js/-/terra.js-3.0.8.tgz",
+      "integrity": "sha512-TSosUWw1OeZmgliHwgydDBgEEl+dGnAoFeaYmYYv+dzcYFnyUwY4NXpvg2cU0rjPBLGQHQdV/zRRfSyNQlGDBQ==",
       "dependencies": {
         "@terra-money/terra.proto": "^0.1.7",
         "axios": "^0.24.0",
@@ -562,6 +564,11 @@
         "node": "*"
       }
     },
+    "node_modules/ms-typescript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms-typescript/-/ms-typescript-2.0.0.tgz",
+      "integrity": "sha512-47wAq6QgJZeFYqQ9k5PbBoyGhZsxOzwmTee2fna5+7coYuidaUFdACrKDbtOuLChFQOsSTS5dEyuplC52E5S8g=="
+    },
     "node_modules/nan": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
@@ -779,10 +786,15 @@
         "node": ">=8.17.0"
       }
     },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
+    },
     "node_modules/ts-node": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
-      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
       "dependencies": {
         "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",
@@ -795,11 +807,13 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.0",
         "yn": "3.1.1"
       },
       "bin": {
         "ts-node": "dist/bin.js",
         "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
         "ts-node-script": "dist/bin-script.js",
         "ts-node-transpile-only": "dist/bin-transpile.js",
         "ts-script": "dist/bin-script-deprecated.js"
@@ -836,6 +850,14 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/typescript-plugin-toml": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/typescript-plugin-toml/-/typescript-plugin-toml-0.2.0.tgz",
+      "integrity": "sha512-K8P1NI8A/SAVqapEnujbhXF0hjf6Qu/SoWsIFaTLszpbaOhnr9r7jddg41T6gj9w02u+3OW4NkWAI6veRMpp3Q==",
+      "dependencies": {
+        "toml": "^3.0.0"
+      }
+    },
     "node_modules/utf-8-validate": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.8.tgz",
@@ -852,6 +874,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
+      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA=="
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.2.0",
@@ -972,9 +999,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@terra-money/terra.js": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@terra-money/terra.js/-/terra.js-3.0.4.tgz",
-      "integrity": "sha512-PEYaPs0p521njZyD6a7aH6KrXRKdj4+j7kboM4qGc8FS/lKPFQUgacsVSlbAK0sYX/tOhINvN7eudwRBwuJVhw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@terra-money/terra.js/-/terra.js-3.0.8.tgz",
+      "integrity": "sha512-TSosUWw1OeZmgliHwgydDBgEEl+dGnAoFeaYmYYv+dzcYFnyUwY4NXpvg2cU0rjPBLGQHQdV/zRRfSyNQlGDBQ==",
       "requires": {
         "@terra-money/terra.proto": "^0.1.7",
         "axios": "^0.24.0",
@@ -1377,6 +1404,11 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "ms-typescript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms-typescript/-/ms-typescript-2.0.0.tgz",
+      "integrity": "sha512-47wAq6QgJZeFYqQ9k5PbBoyGhZsxOzwmTee2fna5+7coYuidaUFdACrKDbtOuLChFQOsSTS5dEyuplC52E5S8g=="
+    },
     "nan": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
@@ -1534,10 +1566,15 @@
         "rimraf": "^3.0.0"
       }
     },
+    "toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
+    },
     "ts-node": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
-      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
       "requires": {
         "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",
@@ -1550,6 +1587,7 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.0",
         "yn": "3.1.1"
       }
     },
@@ -1563,6 +1601,14 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
       "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg=="
     },
+    "typescript-plugin-toml": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/typescript-plugin-toml/-/typescript-plugin-toml-0.2.0.tgz",
+      "integrity": "sha512-K8P1NI8A/SAVqapEnujbhXF0hjf6Qu/SoWsIFaTLszpbaOhnr9r7jddg41T6gj9w02u+3OW4NkWAI6veRMpp3Q==",
+      "requires": {
+        "toml": "^3.0.0"
+      }
+    },
     "utf-8-validate": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.8.tgz",
@@ -1575,6 +1621,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
+      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA=="
     },
     "web-streams-polyfill": {
       "version": "3.2.0",

--- a/pseudo-feeder/package.json
+++ b/pseudo-feeder/package.json
@@ -12,10 +12,10 @@
     "@terra-money/terra.js": "^3.0.8",
     "@types/node": "^17.0.8",
     "bluebird": "^3.7.2",
-    "ms-typescript": "^2.0.0",
+    "ms": "^2.1.3",
     "node-fetch": "^3.1.1",
+    "toml": "^3.0.0",
     "ts-node": "^10.7.0",
-    "typescript": "^4.1.3",
-    "typescript-plugin-toml": "^0.2.0"
+    "typescript": "^4.1.3"
   }
 }

--- a/pseudo-feeder/package.json
+++ b/pseudo-feeder/package.json
@@ -9,11 +9,13 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@terra-money/terra.js": "^3.0.3",
+    "@terra-money/terra.js": "^3.0.8",
     "@types/node": "^17.0.8",
     "bluebird": "^3.7.2",
+    "ms-typescript": "^2.0.0",
     "node-fetch": "^3.1.1",
-    "ts-node": "^10.0.0",
-    "typescript": "^4.1.3"
+    "ts-node": "^10.7.0",
+    "typescript": "^4.1.3",
+    "typescript-plugin-toml": "^0.2.0"
   }
 }


### PR DESCRIPTION

**before merge this, terramoney/pseudo-feeder:0.5.6 have to be published**

changes
- config/config.toml will be mounted on pseudo-feeder
  - pseudo-feeder uses consensus.timeout_commit in config.toml
- interval of querying mainnet has changed from 5s to 10s: to avoid rate limit
- no static fee