### PR TITLE
feat: increasing STKN CW20 initial balance

### DIFF
--- a/config/genesis.json
+++ b/config/genesis.json
@@ -556,7 +556,7 @@
               "decimals": 6,
               "initial_balances": [
                 {
-                  "amount": "1000000",
+                  "amount": "1000000000000",
                   "address": "terra1dcegyrekltswvyy0xy69ydgxn9x8x32zdtapd8"
                 }
               ]


### PR DESCRIPTION
Increasing initial balance of STKN CW20 token from 1 to 1,000,000 in genesis.json.  Larger funds are needed so developers may more easily test functionality of smart contracts without worry of funds.